### PR TITLE
chore: update thatopen components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "7.0.0",
-        "@thatopen/components": "2.3.11",
-        "three": "0.160.1"
+        "@thatopen/components": "^3.1.2",
+        "three": "^0.179.1"
       },
       "bin": {
         "check-ifc": "index.js"
@@ -222,35 +222,45 @@
       }
     },
     "node_modules/@thatopen/components": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/@thatopen/components/-/components-2.3.11.tgz",
-      "integrity": "sha512-y2Fd7yEX4seVsTJFdZYrpl/yJUD8rBbhYk816Z/0KIlhBKoEyzKqkcRhQvhIC4wXOWIng9gET0gxkm1a+JraVA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@thatopen/components/-/components-3.1.2.tgz",
+      "integrity": "sha512-timqgcq7B7cc8JlwHfIeVeXK4MLIzU+j/C4npBdOQfJZbmA/qNwbZwSa4ZwWsoMtb/EWR7hO6u0G2h1EKNwwRA==",
       "license": "MIT",
       "dependencies": {
-        "camera-controls": "2.7.3",
+        "camera-controls": "^2.9.0",
         "fast-xml-parser": "4.4.1",
         "jszip": "3.10.1",
         "three-mesh-bvh": "0.7.0"
       },
       "peerDependencies": {
-        "@thatopen/fragments": "~2.3.0",
-        "three": "^0.160.1",
-        "web-ifc": "0.0.59"
+        "@thatopen/fragments": "~3.1.0",
+        "three": ">=0.175.0",
+        "web-ifc": "0.0.70"
       }
     },
     "node_modules/@thatopen/fragments": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@thatopen/fragments/-/fragments-2.3.0.tgz",
-      "integrity": "sha512-WVp3tHhEj1l4B2MXBqnIgs5vUwKqp6Uz0TGVHHTTrN6lpUI/NvLXS2G//QMX5wJS746htkIC7+2lIScNKpUNHg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@thatopen/fragments/-/fragments-3.1.6.tgz",
+      "integrity": "sha512-aVuNRaR1CMuwO5AP6ReT2DRGsPWFChyJToOtYhAXo6slAqCGFjXbc6lPWqY1HdWwIB4bYzFMmDFuCdQFv4eMTg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "flatbuffers": "23.3.3",
-        "three-mesh-bvh": "0.7.0"
+        "earcut": "^3.0.1",
+        "flatbuffers": "25.2.10",
+        "lru-cache": "11.1.0",
+        "pako": "2.1.0"
       },
       "peerDependencies": {
-        "three": "^0.160.1"
+        "three": ">=0.175",
+        "web-ifc": "0.0.70"
       }
+    },
+    "node_modules/@thatopen/fragments/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)",
+      "peer": true
     },
     "node_modules/@types/node": {
       "version": "22.7.9",
@@ -302,9 +312,9 @@
       }
     },
     "node_modules/camera-controls": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.7.3.tgz",
-      "integrity": "sha512-L4mxjBd3u8qiOLozdWrH2P8ZybSsDXBF7iyNyqNEFJhPUkovmuARWR8JTc1B/qlclOIg6FvZZA/0uAZMMim0mw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
+      "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==",
       "license": "MIT",
       "peerDependencies": {
         "three": ">=0.126.1"
@@ -349,6 +359,13 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -392,10 +409,10 @@
       }
     },
     "node_modules/flatbuffers": {
-      "version": "23.3.3",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.3.3.tgz",
-      "integrity": "sha512-jmreOaAT1t55keaf+Z259Tvh8tR/Srry9K8dgCgvizhKSEr6gLGgaOJI2WFL5fkOpGOGRZwxUrlFn0GCmXUy6g==",
-      "license": "SEE LICENSE IN LICENSE.txt",
+      "version": "25.2.10",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.2.10.tgz",
+      "integrity": "sha512-7JlN9ZvLDG1McO3kbX0k4v+SUAg48L1rIwEvN6ZQl/eCtgJz9UylTMzE9wrmYrcorgxm3CX/3T/w5VAub99UUw==",
+      "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/iconv-lite": {
@@ -456,6 +473,16 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/mute-stream": {
@@ -575,9 +602,9 @@
       "license": "MIT"
     },
     "node_modules/three": {
-      "version": "0.160.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
-      "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
+      "version": "0.179.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.179.1.tgz",
+      "integrity": "sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==",
       "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
@@ -627,9 +654,10 @@
       "license": "MIT"
     },
     "node_modules/web-ifc": {
-      "version": "0.0.59",
-      "resolved": "https://registry.npmjs.org/web-ifc/-/web-ifc-0.0.59.tgz",
-      "integrity": "sha512-5XpzcdBblsK9FkjNpPd8YrWXmZn4vzRQUnz3jrm31/7pz/riscj3KK0dq8MVccuiEkKU8AxueotOi6pidHp1RA==",
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/web-ifc/-/web-ifc-0.0.70.tgz",
+      "integrity": "sha512-uAeq7x0w7Nv0x2WUaUJrWosju/AfHkLXUhmWO9T/0QbXEHsi3K7yl/gBsJM3PM9APl1YPa2nxKYNBc1b8rRWNg==",
+      "license": "MPL-2.0",
       "peer": true
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "description": "CLI tool to verify IFC information requirements",
   "dependencies": {
     "@inquirer/prompts": "7.0.0",
-    "@thatopen/components": "2.3.11",
-    "three": "0.160.1"
+    "@thatopen/components": "^3.1.2",
+    "three": "^0.179.1"
   }
 }

--- a/src/ifcCheck.js
+++ b/src/ifcCheck.js
@@ -47,7 +47,7 @@ export const checkIFC = async () => {
 
     viewpoint.selectionComponents.add(...failingGuids)
     const comment = `${topic.description}: Found ${failingGuids.length} failing`
-    topic.createComment = comment
+    topic.createComment(comment)
 
     console.log(comment)
 


### PR DESCRIPTION
## Summary
- upgrade to `@thatopen/components` v3 and compatible `three`
- adjust IFC check comment creation for new API
